### PR TITLE
Smartproperty fixes

### DIFF
--- a/DarkEdif/Lib/Shared/DarkEdif.cpp
+++ b/DarkEdif/Lib/Shared/DarkEdif.cpp
@@ -740,6 +740,9 @@ Prop * DarkEdif::Properties::GetProperty(size_t IDParam)
 	}
 	else if (!_stricmp(curStr, "Editbox Number") || !_stricmp(curStr, "Edit Spin") || !_stricmp(curStr, "Edit Slider"))
 		ret = new Prop_SInt(*(const int *)Current->ReadPropValue());
+	else if (!_stricmp(curStr, "Editbox Float") || !_stricmp(curStr, "Edit spin float")) {
+		ret = new Prop_Float(*(const float *)Current->ReadPropValue());
+    }
 	else if (!_strnicmp(curStr, "Combo Box", sizeof("Combo Box") - 1))
 	{
 		// Combo box is stored as its item text, so items can be altered between versions.
@@ -1472,6 +1475,7 @@ struct Properties::JSONPropertyReader : Properties::PropertyReader
 		case IDs::PROPTYPE_EDITBUTTON:
 		case IDs::PROPTYPE_LEFTCHECKBOX:
 		case IDs::PROPTYPE_URLBUTTON:
+		case IDs::PROPTYPE_GROUP:
 		{
 			// No data for these. We store just metadata so getting property by index has consistent indexes
 			DebugProp_OutputString(_T("JSDNPropertyReader: Got static type %i (%hs) for property title %hs, ID %zu. Storing just metadata.\n"),
@@ -1590,13 +1594,14 @@ struct Properties::JSONPropertyReader : Properties::PropertyReader
 					title, id, DarkEdif::JSON::LanguageName());
 			}
 
-			static float f = (float)prop["DefaultState"].u.dbl;
+			float* f = new float;
+            *f = (float)convState->jsonProps[id]["DefaultState"].u.dbl;
 
 			// convState->resetPropertiesStream << title << " = " << std::setprecision(3) << f << "\n";
 			convState->resetPropertiesStream << title << "\n";
 			++convState->numPropsReset;
 
-			return convRet->Return_OK(&f, sizeof(float));
+			return convRet->Return_OK(f, sizeof(float), [](const void* v) { delete v; });
 		}
 
 		case IDs::PROPTYPE_CUSTOM:


### PR DESCRIPTION
This pull request fixes few bugs with smartproperties i found while porting my extension.

1. Fixed "GetProperty error: type Editbox Float is unexpected"
2. Fixed PROPTYPE_GROUP being ignored by every property reader which was producing errors about corrupted properties
3. Fixed json prop reader incorrectly initializing multiple float properties with DefaultState of the first one in DarkExt.json