### PR TITLE
Fix Editbox Numbers retaining first value

### DIFF
--- a/DarkEdif/Lib/Shared/DarkEdif.cpp
+++ b/DarkEdif/Lib/Shared/DarkEdif.cpp
@@ -1609,6 +1609,9 @@ struct Properties::JSONPropertyReader : Properties::PropertyReader
 			++convState->numPropsReset;
 
 			static int intData2 = (int)intDataAsLong;
+			
+			intData2 = (int)intDataAsLong;
+			
 			return convRet->Return_OK(&intData2, sizeof(int));
 		}
 		case IDs::PROPTYPE_EDIT_FLOAT:

--- a/DarkEdif/Lib/Shared/DarkEdif.cpp
+++ b/DarkEdif/Lib/Shared/DarkEdif.cpp
@@ -1608,8 +1608,7 @@ struct Properties::JSONPropertyReader : Properties::PropertyReader
 			convState->resetPropertiesStream << title << '\n';
 			++convState->numPropsReset;
 
-			static int intData2 = (int)intDataAsLong;
-			
+			static int intData2;
 			intData2 = (int)intDataAsLong;
 			
 			return convRet->Return_OK(&intData2, sizeof(int));


### PR DESCRIPTION
If you had multiple Editbox Numbers in the JSON of an ext, they would all share the same value of the first one due to a bug with GetProperty() using a static variable to return the property.