### PR TITLE
Misc

### DIFF
--- a/DarkEdif/Inc/Android/MMFAndroidMasterHeader.hpp
+++ b/DarkEdif/Inc/Android/MMFAndroidMasterHeader.hpp
@@ -15,7 +15,7 @@
 #include "../Shared/AllPlatformDefines.hpp"
 #include "../Shared/NonWindowsDefines.hpp"
 
-#include <asm-generic\posix_types.h>
+#include <asm-generic/posix_types.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <iostream>

--- a/DarkEdif/Inc/Shared/AllPlatformDefines.hpp
+++ b/DarkEdif/Inc/Shared/AllPlatformDefines.hpp
@@ -104,7 +104,7 @@ using namespace std::string_view_literals;
 #elif defined(__clang__) && !defined (__INTELLISENSE__)
 	#define PrintFHintInside /* no op */
 	// Defined after a C printf-style function declaration to allow code analysers to check the %x are correct type
-	#define PrintFHintAfter(formatParamIndex,dotsParamIndex) __printflike(formatParamIndex, dotsParamIndex)
+	#define PrintFHintAfter(formatParamIndex,dotsParamIndex) __attribute__((format(printf, formatParamIndex, dotsParamIndex)))
 #else
 	// Defined inside a C printf-style function declaration + definition to allow code analysers to check argument types.
 	#define PrintFHintInside /* no op */
@@ -335,10 +335,10 @@ enum_class_is_a_bitmask(TextCapacity);
 
 // ==================================================================================================
 // DarkEdif logging and macros.
-// 
+//
 // These are printf-based, and expect a newline at end:
 // LOGI(_T("Some text with variable: %d\n"), 50);
-// 
+//
 // Log levels are based on the ANDROID_LOG_XXX enum; in order of highest to lowest severity:
 // LOGF, LOGE, LOGW, LOGI, LOGD, LOGV.
 //

--- a/DarkEdif/Inc/Shared/DarkEdif.hpp
+++ b/DarkEdif/Inc/Shared/DarkEdif.hpp
@@ -686,12 +686,14 @@ namespace DarkEdif {
 		FontInfoMultiPlat(jobject nativeFont);
 		// Creates a copy of font settings of this native font
 		void SetFont(const jobject nativeFont);
-#else // Apple
+#elif defined(__APPLE__)
 		CFontInfo* cfontinfo = nullptr;
 		// Creates a font info pointing to a native font
 		FontInfoMultiPlat(CFontInfo* nativeFont);
 		// Creates a copy of font settings of this native font
 		void SetFont(const void* const nativeFont);
+#else
+	#error Unexpected platform
 #endif
 #if TEXT_OEFLAG_EXTENSION
 		// Creates a runtime-usable font from a EDITDATA font, tying it to an ext

--- a/DarkEdif/Inc/Shared/Edif.hpp
+++ b/DarkEdif/Inc/Shared/Edif.hpp
@@ -25,13 +25,13 @@ class Prop;
 	#include "..\Windows\MMFWindowsMasterHeader.hpp"
 	extern HINSTANCE hInstLib;
 #elif defined (__ANDROID__)
-	#include "..\Android\MMFAndroidMasterHeader.hpp"
+	#include "../Android/MMFAndroidMasterHeader.hpp"
 #elif defined (__APPLE__)
-#if MacBuild == 0
-	#include "../iOS/MMFiOSMasterHeader.hpp"
-#else
-	#include "../Mac/MMFMacMasterHeader.hpp"
-#endif
+	#if MacBuild == 0
+		#include "../iOS/MMFiOSMasterHeader.hpp"
+	#else
+		#include "../Mac/MMFMacMasterHeader.hpp"
+	#endif
 #else
 	#error Unexpected platform
 #endif
@@ -217,9 +217,11 @@ namespace Edif
 		// Attaches current thread, and gets JNIEnv for it; errors are fatal
 		static void AttachJVMAccessForThisThread(const char * threadName, bool asDaemon = false);
 		static void DetachJVMAccessForThisThread();
-#else
+#elif defined(__APPLE__)
 		Runtime(Extension* ext, void * const objCExtPtr);
 		void * curCEvent;
+#else
+	#error Unexpected platform
 #endif
 
 		DarkEdif::FontInfoMultiPlat* extFont = NULL;

--- a/DarkEdif/Inc/Shared/SurfaceMultiPlat.hpp
+++ b/DarkEdif/Inc/Shared/SurfaceMultiPlat.hpp
@@ -371,11 +371,13 @@ namespace DarkEdif
 		//global<jobject> paint;
 		//global<jclass> paintClass;
 	public:
-	#else // apple
+	#elif defined(__APPLE__)
 		// Raw pixels, size and clip rectangle
 		CRenderToTexture* bmp = nullptr;
 		// Data around an image, can wrap a bmp and collision masks
 		//CImage* img;
+	#else
+		#error Unexpected platform
 	#endif
 		/** Updates screen display manually. Runtime does not auto-redraw in some display modes.
 		 * @param zone If NULL or not specified, the whole surface. */

--- a/DarkEdif/Inc/Windows/MMFWindowsMasterHeader.hpp
+++ b/DarkEdif/Inc/Windows/MMFWindowsMasterHeader.hpp
@@ -3526,6 +3526,13 @@ enum class BUILDTYPE {
 	XNA_PHONE,
 	XNA_XBOX_APP,
 	XNA_PHONE_APP,
+	HTML5,
+	VITA,
+	VITADEVEL,
+	VITAFINAL,		// no longer used
+	HTML5DEVEL,
+	HTML5FINAL,
+	OUYA,
 	STDMAX,			// end of standard build types
 };
 

--- a/DarkEdif/Lib/Shared/DarkEdif.cpp
+++ b/DarkEdif/Lib/Shared/DarkEdif.cpp
@@ -5372,7 +5372,7 @@ void DarkEdif::FontInfoMultiPlat::SetFont(const jobject ptr) {
 	JavaAndCString str((jstring)threadEnv->GetObjectField(ptr, lfFaceName));
 	fontNameDesired = str.str();
 }
-#else // apple
+#elif defined(__APPLE__)
 DarkEdif::FontInfoMultiPlat::FontInfoMultiPlat(CFontInfo* ptr) {
 	cfontinfo = ptr;
 	SetFont(cfontinfo);
@@ -5386,7 +5386,8 @@ void DarkEdif::FontInfoMultiPlat::SetFont(const void * ptr2) {
 	strikeOut = ptr->lfStrikeOut != 0;
 	fontNameDesired = [ptr->lfFaceName UTF8String];
 }
-
+#else
+	#error Unexpected platform
 #endif
 
 DarkEdif::FontInfoMultiPlat::FontInfoMultiPlat() {
@@ -5676,8 +5677,10 @@ int DarkEdif::GetCurrentFusionEventNum(const Extension * const ext)
 	}
 
 	return threadEnv->CallIntMethod(ext->javaExtPtr, getEventIDMethod);
-#else // iOS
+#elif defined(__APPLE__)
 	return DarkEdifObjCFunc(PROJECT_TARGET_NAME_UNDERSCORES_RAW, getCurrentFusionEventNum)(ext->objCExtPtr);
+#else
+	#error Unexpected platform
 #endif
 }
 
@@ -5715,8 +5718,10 @@ std::tstring DarkEdif::MakePathUnembeddedIfNeeded(const Extension * ext, const s
 	JavaAndCString newPath((jstring)threadEnv->CallObjectMethod(ext->javaExtPtr, getEventIDMethod, origPath.javaRef));
 	// Copy the C++ memory out into its own variable
 	const std::string truePath(newPath.str());
-#else
+#elif defined(__APPLE__)
 	const std::string truePath = DarkEdifObjCFunc(PROJECT_TARGET_NAME_UNDERSCORES_RAW, makePathUnembeddedIfNeeded)(ext->objCExtPtr, std::string(filePath).c_str());
+#else
+	#error Unexpected platform
 #endif
 	if (filePath != truePath)
 		LOGV(_T("File path extracted from \"%s\" to \"%s\".\n"), std::tstring(filePath).c_str(), truePath.c_str());
@@ -6272,7 +6277,7 @@ void DarkEdif::LOGFInternal(PrintFHintInside const TCHAR * x, ...)
 	DarkEdif::MsgBox::Error(_T("Fatal error"), _T("%s"), buf);
 	std::abort();
 }
-#else // APPLE
+#elif defined(__APPLE__)
 
 #include <unistd.h>
 #include <sys/syscall.h>
@@ -6409,6 +6414,8 @@ void DarkEdif::LOGFInternal(PrintFHintInside const TCHAR * x, ...)
 	va_end(va);
 	exit(EXIT_FAILURE);
 }
+#else
+	#error Unexpected platform
 #endif
 
 
@@ -6435,7 +6442,7 @@ bool DarkEdif::IsDebuggerAttached()
 				return std::stoi(line.substr(10)) != 0;
 		// if no match, fall thru
 	}
-#else // APPLE
+#elif defined(__APPLE__)
 	// Apple is heavily sandboxed. This solution seems like it should work on non-jailbroken iOS.
 	// Other possible alternatives for Apple: getppid() != 1 or isatty(STDERR_FILENO)
 	int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid() };
@@ -6446,7 +6453,9 @@ bool DarkEdif::IsDebuggerAttached()
 	if (!sysctl(mib, 4, &info, &size, nullptr, 0))
 		return (info.kp_proc.p_flag & P_TRACED) != 0;
 	LOGE(_T("Couldn't detect debugger: sysctl() returned error %d\n"), errno);
-#endif // Apple
+#else
+	#error Unexpected platform
+#endif
 
 #ifdef _DEBUG
 	// If debug, if debugger detect fails, we'll assume a debugger is present.
@@ -6793,7 +6802,7 @@ namespace DarkEdif
 
 		// To not make this ANSI ext clobber the debugger's text with replacement characters,
 		// we always talk to CF2.5+ with Wide characters
-		
+
 		// Move caret to end of Fusion debugger text
 		int curTextLen = GetWindowTextLengthW(CF25PlusEditBoxHandle);
 		// On error, default to passing -1, -1, which resets caret

--- a/DarkEdif/Lib/Shared/Edif.General.cpp
+++ b/DarkEdif/Lib/Shared/Edif.General.cpp
@@ -768,7 +768,7 @@ ProjectFunc void JNICALL JNI_OnUnload([[maybe_unused]] JavaVM * vm, [[maybe_unus
 #endif // DARKEDIF_SIGNAL_HANDLERS
 }
 
-#else // iOS
+#elif defined(__APPLE__)
 #include "Extension.hpp"
 #include "MMF2Lib/CTexture.h"
 #include "MMF2Lib/CImage.h"
@@ -840,7 +840,9 @@ Extension* RunObject::GetExtension()
 	return (Extension *)DarkEdifObjCFunc(PROJECT_TARGET_NAME_UNDERSCORES_RAW, getCPtr)((CExtension *)this);
 }
 
-#endif // Apple
+#else
+	#error Unexpected platform
+#endif
 
 
 #if DARKEDIF_DISPLAY_TYPE > DARKEDIF_DISPLAY_ANIMATIONS

--- a/DarkEdif/Lib/Shared/Edif.Runtime.cpp
+++ b/DarkEdif/Lib/Shared/Edif.Runtime.cpp
@@ -99,10 +99,12 @@ std::vector<short> qualToOi::HalfVector(std::size_t first)
 		get_OiList(0);
 	for (std::size_t i = first; i < OiAndOiListLength; i += 2)
 		list.push_back(OiAndOiList[i]);
-#else // apple
+#elif defined(__APPLE__)
 	const short* const qoiList = ((CQualToOiList*)this)->qoiList;
 	for (std::size_t i = first; qoiList[i] != -1; i += 2)
 		list.push_back(qoiList[i]);
+#else
+	#error Unexpected platform
 #endif
 	return list;
 }
@@ -118,7 +120,7 @@ CRunAppMultiPlat* CRunAppMultiPlat::get_ParentApp() {
 	return ParentApp;
 #elif defined(__APPLE__)
 	return (CRunAppMultiPlat*)((CRunApp*)this)->parentApp;
-#else // Android
+#elif defined(__ANDROID__)
 	if (!parentApp && !parentAppIsNull)
 	{
 		// Application/CRunApp parentApp
@@ -132,6 +134,8 @@ CRunAppMultiPlat* CRunAppMultiPlat::get_ParentApp() {
 			parentAppIsNull = true;
 	}
 	return parentApp.get();
+#else
+	#error Unexpected platform
 #endif
 }
 
@@ -140,7 +144,7 @@ std::size_t CRunAppMultiPlat::GetNumFusionFrames() {
 	return hdr.NbFrames;
 #elif defined(__APPLE__)
 	return (std::size_t)((CRunApp*)this)->gaNbFrames;
-#else // Android
+#elif defined(__ANDROID__)
 	if (numTotalFrames == 0)
 	{
 		jfieldID fieldID = threadEnv->GetFieldID(meClass, "gaNbFrames", "I");
@@ -150,6 +154,8 @@ std::size_t CRunAppMultiPlat::GetNumFusionFrames() {
 		numTotalFrames = (std::size_t)totalFrames;
 	}
 	return numTotalFrames;
+#else
+	#error Unexpected platform
 #endif
 }
 
@@ -1580,11 +1586,10 @@ void Edif::Runtime::AttachJVMAccessForThisThread(const char* threadName, bool as
 
 	pthread_setname_np(pthread_self(), threadName);
 
-	JavaVMAttachArgs args = {
-		.name = threadName,
-		.group = NULL,
-		.version = JNI_VERSION_1_6
-	};
+	JavaVMAttachArgs args = {};
+	args.name = threadName;
+	args.group = NULL;
+	args.version = JNI_VERSION_1_6;
 	// Daemon means the JVM won't keep the app running if this thread is still alive.
 	// Do you want main thread exiting to choose whether the app is running or not?
 	jint error;
@@ -3799,7 +3804,7 @@ EventGroupMP::EventGroupMP(jobject me, Edif::Runtime * runtime) :
 	}
 }
 
-#else // iOS
+#elif defined(__APPLE__)
 #include "MMF2Lib/CRunExtension.h"
 #include "MMF2Lib/CRun.h"
 #include "MMF2Lib/CObject.h"
@@ -4397,6 +4402,8 @@ event2* EventGroupMP::GetCAByIndex(size_t index)
 	return ret;
 }
 
-#endif // APPLE
+#else // not APPLE
+	#error Unexpected platform
+#endif // not APPLE
 
 #endif // Apple or Android

--- a/DarkEdif/Lib/Shared/Edif.cpp
+++ b/DarkEdif/Lib/Shared/Edif.cpp
@@ -37,7 +37,7 @@ bool Edif::IS_COMPATIBLE(mv * v)
 {
 	// mV is not valid at runtime; so someone's trying to use a Runtime MFX as Editor,
 	// which won't work anyway because Runtime MFX lacks A/C/E menus and such.
-	
+
 	// No GetVersion function provided, abort
 	if (!v->GetVersion)
 		return false;
@@ -327,7 +327,7 @@ int Edif::Init(mv * mV, bool fusionStartupScreen)
 	{
 		DarkEdif::Internal_WindowHandle = mV->HMainWin;
 		DarkEdif::IsFusion25 = ((mV->GetVersion() & MMFVERSION_MASK) == CFVERSION_25);
-		
+
 		// 2.0 uses floats for angles if it's a Direct3D display, Software or DirectDraw uses int
 		// Fusion 2.5 always uses floats, even in Software, and doesn't use DirectDraw at all
 		DarkEdif::IsHWAFloatAngles = DarkEdif::IsFusion25 || mvIsHWAVersion(mV) != FALSE;
@@ -371,7 +371,7 @@ int Edif::Init(mv * mV, bool fusionStartupScreen)
 			= (decltype(pIsWow64Process2))GetProcAddress(kernDll, "IsWow64Process2");
 		BOOL (WINAPI * pIsWow64Process)(HANDLE hProcess, _Out_ PBOOL Wow64Process)
 			= (decltype(pIsWow64Process))GetProcAddress(kernDll, "IsWow64Process");
-		
+
 		// If this Win10+ func is defined, use it to check if emulation is active
 		// This is the way to distinguish Windows ARM64.
 		if (pIsWow64Process2)
@@ -379,7 +379,7 @@ int Edif::Init(mv * mV, bool fusionStartupScreen)
 			USHORT procMachine, nativeMachine;
 			if (!pIsWow64Process2(curProc, &procMachine, &nativeMachine))
 				return DarkEdif::MsgBox::Error(_T("DarkEdif CPU detection error"), _T("Couldn't detect CPU arch: IsWow64Process2() error %u."), GetLastError()), -1;
-			
+
 			// If unknown process machine, it matches native machine, so we're not under emulation.
 			if (procMachine == IMAGE_FILE_MACHINE_UNKNOWN)
 				procMachine = nativeMachine;
@@ -1263,7 +1263,7 @@ jmethodID ConditionOrActionManager_Android::getActOrCondParamInt,
 	ConditionOrActionManager_Android::getCndParamString, ConditionOrActionManager_Android::getCndParamFloat, ConditionOrActionManager_Android::getCndParamObject,
 	ConditionOrActionManager_Android::setCndRetInt, ConditionOrActionManager_Android::setCndRetFloat, ConditionOrActionManager_Android::setCndRetString;
 jfieldID ConditionOrActionManager_Android::getRH;
-#else
+#elif defined(__APPLE__)
 
 extern "C"
 {
@@ -1353,6 +1353,8 @@ struct ConditionOrActionManager_iOS : ACEParamReader
 	}
 };
 } // namespace FusionInternals
+#else
+	#error Unexpected platform
 #endif
 
 #ifdef _WIN32
@@ -1368,12 +1370,14 @@ ProjectFunc jlong conditionJump(JNIEnv *, jobject, jlong extPtr, int ID, CCndExt
 	ConditionOrActionManager_Android params(true, ext, (jobject)cndExt);
 	global<jobject> lastCEvent = ext->Runtime.curCEvent.swap_out(); // prevent subfunctions causing this variable to be incorrect
 	ext->Runtime.curCEvent = global((jobject)cndExt, "Current Cnd ext");
-#else
+#elif defined(__APPLE__)
 ProjectFunc long PROJ_FUNC_GEN(PROJECT_TARGET_NAME_UNDERSCORES_RAW, _conditionJump(void * cppExtPtr, int ID, void * cndExt))
 {
 	Extension* const ext = (Extension*)cppExtPtr;
 	ConditionOrActionManager_iOS params(true, ext, cndExt);
 	ext->Runtime.curCEvent = cndExt;
+#else
+	#error Unexpected platform
 #endif
 	LOGV(PROJECT_NAME _T(" Condition ID %i start.\n"), ID);
 
@@ -1429,7 +1433,7 @@ ProjectFunc void actionJump(JNIEnv *, jobject, jlong extPtr, jint ID, CActExtens
 	const jobject lastAct = ext->Runtime.curRH4ActBasedOnCEventOnly;
 	ext->Runtime.curRH4ActBasedOnCEventOnly = ext->Runtime.curCEvent.ref;
 #define actreturn /* void */
-#else
+#elif defined(__APPLE__)
 ProjectFunc void PROJ_FUNC_GEN(PROJECT_TARGET_NAME_UNDERSCORES_RAW, _actionJump(void * cppExtPtr, int ID, void * act))
 {
 	Extension* ext = (Extension*)cppExtPtr;
@@ -1437,6 +1441,8 @@ ProjectFunc void PROJ_FUNC_GEN(PROJECT_TARGET_NAME_UNDERSCORES_RAW, _actionJump(
 	auto lastCEvent = ext->Runtime.curCEvent;
 	ext->Runtime.curCEvent = act;
 #define actreturn /* void */
+#else
+	#error Unexpected platform
 #endif
 	LOGV(PROJECT_NAME _T(" Action ID %i start.\n"), ID);
 
@@ -1622,7 +1628,7 @@ struct ExpressionManager_Windows : ACEParamReader {
 	}
 
 };
-#else
+#elif defined(__APPLE__)
 // segregate to prevent two iOS exts conflicting
 inline namespace FusionInternals {
 struct ExpressionManager_iOS : ACEParamReader {
@@ -1681,6 +1687,8 @@ struct ExpressionManager_iOS : ACEParamReader {
 	}
 };
 } // namespace FusionInternals
+#else
+	#error Unexpected platform
 #endif
 
 #ifdef _WIN32
@@ -1700,11 +1708,13 @@ ProjectFunc void expressionJump(JNIEnv *, jobject, jlong extPtr, jint ID, CNativ
 	// whereas an expresssion is a sub-variable of a CEvent.
 	//if (ext->Runtime.curCEvent.invalid())
 	//	ext->Runtime.curCEvent = global((jobject)expU, "Current Exp ext");
-#else
+#elif defined(__APPLE__)
 ProjectFunc void PROJ_FUNC_GEN(PROJECT_TARGET_NAME_UNDERSCORES_RAW, _expressionJump(void * cppExtPtr, int ID))
 {
 	Extension* ext = (Extension*)cppExtPtr;
 	ExpressionManager_iOS params(ext);
+#else
+	#error Unexpected platform
 #endif
 
 	if (Edif::SDK->ExpressionFunctions.size() < (unsigned int)ID)
@@ -1948,7 +1958,7 @@ int Edif::GetDependency (char *& Buffer, size_t &Size, const TCHAR * FileExtensi
 	Buffer = (char *)(void *) darkExtJSON;
 	Size = darkExtJSONSize;
 	return DependencyWasResource;
-#else
+#elif defined(__APPLE__)
 	if (_tcsicmp(FileExtension, _T("json")))
 		return DependencyNotFound;
 
@@ -1985,6 +1995,8 @@ int Edif::GetDependency (char *& Buffer, size_t &Size, const TCHAR * FileExtensi
 	AAssetDir_close(assetDir);
 	return DependencyWasFile;
 #endif // File reading
+#else
+	#error Unexpected platform
 #endif // _WIN32
 }
 

--- a/DarkEdif/Lib/Shared/SurfaceMultiPlat.cpp
+++ b/DarkEdif/Lib/Shared/SurfaceMultiPlat.cpp
@@ -37,7 +37,7 @@
 			int hotSpotX, int hotspotY,
 			int x, int y, int w, int h,
 			int shaderIndex, int inkEffect, int inkEffectParam);
-	#else // apple
+	#elif defined(__APPLE__)
 		#ifndef __INTELLISENSE__
 			#import "MMF2Lib/CBitmap.h"
 			#import "MMF2Lib/CImage.h"
@@ -53,7 +53,9 @@
 			#pragma clang diagnostic push
 			#pragma clang diagnostic ignored "-Wunreachable-code"
 		#endif
-	#endif // iOS/Mac
+	#else
+		#error Unexpected platform
+	#endif
 #endif // not Windows
 
 DarkEdif::Rect::Rect(const std::int32_t right, const std::int32_t bottom) :
@@ -1086,7 +1088,7 @@ std::size_t DarkEdif::Surface::Internal_CreateMask(void* mask, const std::uint32
 	return surf->CreateMask((sMask *)mask, flags);
 #else
 	LOGF(_T("%sCannot create mask; not implemented on this platform.\n"), debugID);
-	return SIZE_T_MAX;
+	return SIZE_MAX;
 #endif
 }
 
@@ -1718,7 +1720,7 @@ DarkEdif::Surface::Surface(RunHeader* const rhPtr, bool needBitmapFuncs, bool ne
 	format = PixelFormat::ABGR;
 	hasGeometryCapacity = needBitmapFuncs;
 	hasTextCapacity = needTextFuncs;
-#else // apple
+#elif defined(__APPLE__)
 	//img = [CImage alloc];
 	//[img initWithWidth: (int)width andHeight : (int)height] ;
 
@@ -1739,6 +1741,8 @@ DarkEdif::Surface::Surface(RunHeader* const rhPtr, bool needBitmapFuncs, bool ne
 		format = PixelFormat::ABGR;
 	else
 		format = PixelFormat::BGR;
+#else
+	#error Unexpected platform
 #endif
 
 	LOGI(_T("%sCreated a surface, describing as \"%s\".\n"), debugID, Describe().c_str());
@@ -1854,8 +1858,10 @@ std::tstring DarkEdif::Surface::Describe() const {
 	result << _T("cSurface 0x"sv) << (void*)surf;
 #elif defined(__ANDROID__)
 	result << _T("Java BMP ref 0x"sv) << (void *)textSurface.ref;
-#else // apple
+#elif defined(__APPLE__)
 	result << _T("CBitmap 0x"sv) << (void*)bmp; // << _T(", CImage 0x") << (void*)img;
+#else
+	#error Unexpected platform
 #endif
 	result << _T(". Image ("sv) << GetSize()
 		<< _T("), "sv) << std::dec << sizeBytes << _T(" bytes, "sv);
@@ -1878,12 +1884,14 @@ std::tstring DarkEdif::Surface::Describe() const {
 std::size_t DarkEdif::Surface::GetWidth() const {
 #ifdef _WIN32
 	return (std::size_t)surf->GetWidth();
-#elif defined (__ANDROID__)
+#elif defined(__ANDROID__)
 	const jint width = threadEnv->CallIntMethod(bmp, bitmapGetWidthMethod);
 	JNIExceptionCheck();
 	return width;
-#else // apple
+#elif defined(__APPLE__)
 	return bmp->width;
+#else
+	#error Unexpected platform
 #endif
 }
 std::size_t DarkEdif::Surface::GetHeight() const {
@@ -1893,8 +1901,10 @@ std::size_t DarkEdif::Surface::GetHeight() const {
 	const jint height = threadEnv->CallIntMethod(bmp, bitmapGetHeightMethod);
 	JNIExceptionCheck();
 	return height;
-#else // apple
+#elif defined(__APPLE__)
 	return bmp->height;
+#else
+	#error Unexpected platform
 #endif
 }
 std::size_t DarkEdif::Surface::GetDepth() const {
@@ -2035,9 +2045,11 @@ DarkEdif::Surface::~Surface()
 	surf = nullptr;
 #elif defined(__ANDROID__)
 	// Should auto-free the global refs and delete the object by GC
-#else
+#elif defined(__APPLE__)
 	[bmp release];
 	bmp = nullptr;
+#else
+	#error Unexpected platform
 #endif
 }
 bool DarkEdif::Surface::CopySection(Rect srcRect, Surface& dest, Rect destRect,
@@ -2301,9 +2313,11 @@ bool DarkEdif::Surface::FillImageWith(const SurfaceFill& sf)
 		// Overwrites alpha as well
 		threadEnv->CallVoidMethod(bmp, bitmapEraseMethod, sf.solid.color);
 		JNIExceptionCheck();
-#else // apple
+#elif defined(__APPLE__)
 		// TODO: Alpha?
 		[bmp fillWithColor: sf.solid.color];
+#else
+	#error Unexpected platform
 #endif
 		WasAltered();
 		return true;


### PR DESCRIPTION
Like i said, a collection of random tiny changes from my fork.
Most don't really make a difference here.

- Changed many compile time guards to output an error when building for an unsupported platform. That error gives clear info where changes are needed during porting.
- Fixed an android compiler warning.
- Changed some windows style path separators to the normal ones (/), to fix building with linux version of android ndk.
- Made `PrintFHintAfter` work with any clang compiler. Before it used a macro that is not present on some platforms.
- Added a few missing `BUILDTYPE`s from the og F2.5 sdk.
- Replaced non standard `SIZE_T_MAX` with `SIZE_MAX`.

Also, i don't have a mac to test, so i really hope i didn't make any mistakes there...